### PR TITLE
Change the link to the script from Turkish to default language

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # Privacy Redirector
 This userscript redirects popular social media platforms to their privacy respecting frontends.
 
-You can add the script from [Greasyfork](https://greasyfork.org/tr/scripts/436359-privacy-redirector), or you can clone this repo and add it manually.
+You can add the script from [Greasyfork](https://greasyfork.org/scripts/436359-privacy-redirector), or you can clone this repo and add it manually.


### PR DESCRIPTION
Hello! The link as it is now always sends people to the Turkish translation. I think by removing /tr/ from the link entirely, it should send people to the translation of their own country.

I think...